### PR TITLE
Parse NAC table using chunks (use less RAM)

### DIFF
--- a/src/moon/nacpl/load_nac_metadata.py
+++ b/src/moon/nacpl/load_nac_metadata.py
@@ -2,13 +2,20 @@
 Loads LROC NAC metadata and footprints from local
 """
 
+import typing
+from pandas.io.parsers import TextFileReader
+
 # Read column descriptions from CUMINDEX.LBL
 # this was downloaded from http://lroc.sese.asu.edu/data/LRO-L-LROC-2-EDR-V1.0/LROLRC_0040C/INDEX/
 lblfilepath = r'/INDEX.LBL'
 indfilepath = r'/CUMINDEX.TAB'
 footprintfileglob = r'/moon_lro_lroc_edrnac_ga/*.shp'
 
-def load_nac_index(lblfilepath=lblfilepath, indfilepath=indfilepath):
+CHUNK_SIZE = 5000  # lines
+
+
+def load_nac_index(lblfilepath=lblfilepath, indfilepath=indfilepath, chunksize=CHUNK_SIZE) -> typing.Union[
+    TextFileReader]:
     import pandas
     import pvl
     with open(lblfilepath, 'r') as lblfile:
@@ -18,8 +25,9 @@ def load_nac_index(lblfilepath=lblfilepath, indfilepath=indfilepath):
         col_pvl = lblpvl['INDEX_TABLE'].getlist('COLUMN')
         col_list = [col['NAME'].lower() for col in col_pvl]
 
-        nac_index = pandas.read_csv(indfilepath, header=None, names=col_list)
+        nac_index = pandas.read_csv(indfilepath, header=None, names=col_list, chunksize=chunksize)
     return nac_index
+
 
 def load_nac_footprints(footprintfileglob=footprintfileglob):
     import geopandas


### PR DESCRIPTION
## Parse NAC table using chunks (use less RAM)

* Parse NAC table using chunks: do not load the whole table at once in RAM, this helps keeping RAM usage low.
* Fix unsupported `GeometryCollection` when calling `polygonize` with latest Shapely version (1.8.0)

## Why?

`find_stereo_pairs.py` was eating all my RAM :smile: 

NB: it may be useful to be able to configure `CHUNK_SIZE`