### PR TITLE
RAM optimizations, additional parameters (discussion)

### DIFF
--- a/src/moon/nacpl/download_NAC.py
+++ b/src/moon/nacpl/download_NAC.py
@@ -54,7 +54,8 @@ def download_NAC_image(product_id_or_json: str, download_dir: str):
     else:  # product id
         product_id_list = [product_id_or_json]
 
-    args = [(product_id, download_dir) for product_id in product_id_list]
+    # iterate over set(product_id_list) so that products are only downloaded once
+    args = [(product_id, download_dir) for product_id in set(product_id_list)]
     with Pool(8) as p:
         p.map(download, args)
 

--- a/src/moon/nacpl/download_NAC.py
+++ b/src/moon/nacpl/download_NAC.py
@@ -26,10 +26,12 @@ def get_nac_url(product_id: str):
     :param product_id: PDS id of a NAC, for example M1134059748RE
     :return: URL
     """
-    query_url = f'https://oderest.rsl.wustl.edu/live2/?query=product&PDSID={product_id}&results=f&output=json'
+    query_url = f"https://oderest.rsl.wustl.edu/live2/?query=product&PDSID={product_id}&results=f&output=json"
     resp = request.urlopen(url=query_url)
     resp = json.loads(resp.read())
-    nacurl = resp['ODEResults']['Products']['Product']['Product_files']['Product_file'][0]['URL']
+    nacurl = resp["ODEResults"]["Products"]["Product"]["Product_files"]["Product_file"][
+        0
+    ]["URL"]
     print(nacurl)
     return nacurl
 
@@ -57,5 +59,5 @@ def download_NAC_image(product_id_or_json: str, download_dir: str):
         p.map(download, args)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run(download_NAC_image)

--- a/src/moon/nacpl/download_NAC.py
+++ b/src/moon/nacpl/download_NAC.py
@@ -4,10 +4,19 @@ from clize import run
 from urllib import request
 import json
 import wget
+from multiprocessing import Pool
 
 # Ignore SSL certificate errors, necessary because docker Ubuntu 18.04 image doesn't like wustl.edu cert for some reason
 import ssl
+
 ssl._create_default_https_context = ssl._create_unverified_context
+
+
+def download(arg):
+    (product_id, download_dir) = arg
+    url = get_nac_url(product_id)
+    wget.download(url=url, out=download_dir)
+
 
 def get_nac_url(product_id: str):
     """
@@ -24,15 +33,29 @@ def get_nac_url(product_id: str):
     print(nacurl)
     return nacurl
 
-def download_NAC_image(product_id, download_dir):
+
+def download_NAC_image(product_id_or_json: str, download_dir: str):
     """
     Download a NAC by its product id.
 
-    :param product_id: PDS id of a NAC, for example M1134059748RE
+    :param product_id_or_json: PDS id of a NAC, for example M1134059748RE
     :param download_dir: Directory into which to place the downloaded file
     """
-    url = get_nac_url(product_id)
-    wget.download(url=url, out=download_dir, bar=None)
+    if product_id_or_json.endswith(".json"):  # json file path
+        with open(product_id_or_json) as json_file:
+            data = json.load(json_file)
+            print(data)
+            product_id_list = []
+            for pair in data:
+                product_id_list.append(pair["left"])
+                product_id_list.append(pair["right"])
+    else:  # product id
+        product_id_list = [product_id_or_json]
+
+    args = [(product_id, download_dir) for product_id in product_id_list]
+    with Pool(8) as p:
+        p.map(download, args)
+
 
 if __name__ == '__main__':
     run(download_NAC_image)

--- a/src/moon/nacpl/find_stereo_pairs.py
+++ b/src/moon/nacpl/find_stereo_pairs.py
@@ -10,7 +10,7 @@ Aaron Curtis
 
 
 from nacpl import geom_helpers, load_nac_metadata
-from shapely.geometry import Polygon, LineString
+from shapely.geometry import Polygon, LineString, MultiPolygon
 from shapely import wkt
 import geopandas, pandas
 import re
@@ -140,53 +140,64 @@ class ImageSearch:
         resp = json.loads(resp.read())
         if verbose:
             print(f'Looking in CUMINDEX.TAB for sun & spacecraft geometry info')
-        metadata = load_nac_metadata.load_nac_index(indfilepath=indfilepath, lblfilepath=lblfilepath)
-        metadata.product_id = metadata.product_id.apply(str.strip)
-        metadata.set_index('product_id', inplace=True)
         footprints = pandas.DataFrame(resp['ODEResults']['Products']['Product'])
         # lowercase all column names for ease of joining from different APIs
         footprints.columns = [col.lower() for col in footprints.columns]
         footprints.set_index('pdsid', inplace=True)
-        footprints = footprints.join(metadata, how='inner', lsuffix='_ode', rsuffix='')
-        # For the columns that were in common between CUMINDEX.TAB and ODE REST API, remove the ODE ones and keep the ones form CUMINDEX.TAB
-        footprints = footprints.loc[:,
-                     [col for col in footprints.columns if not col.endswith('_ode')]
-                     ]
-        footprints = footprints.apply(to_numeric_or_date)
 
-        crs = projections[projection]
-        if projection == 'ec':
-            # Use IAU2000:30101
-            crs = '+proj=longlat +a=1737400 +b=1737400 +no_defs'
-            footprints.footprint_geometry = footprints.footprint_geometry.apply(wkt.loads)
-        elif projection == 'sp':
-            # Use IAU2000:30120
-            crs = '+proj=stere +lat_0=-90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs'
-            footprints.footprint_geometry = footprints.footprint_sp_geometry.apply(wkt.loads)
-        elif projection == 'np':
-            # Use IAU2000:30118
-            crs = '+proj=stere +lat_0=90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs'
-            footprints.footprint_geometry = footprints.footprint_np_geometry.apply(wkt.loads)
+        filtered = []
+        chunks_metadata = load_nac_metadata.load_nac_index(indfilepath=indfilepath, lblfilepath=lblfilepath)
+        for chunk_metadata in chunks_metadata:  # iterate over chunks instead of loading all CSV into RAM
+            chunk_metadata.product_id = chunk_metadata.product_id.apply(str.strip)
+            chunk_metadata.set_index('product_id', inplace=True)
+            chunk_footprints = footprints.join(chunk_metadata, how='inner', lsuffix='_ode', rsuffix='')
 
-        if verbose:
-            print(f'{len(footprints)} NACs were listed in the CUMINDEX.TAB file')
-        footprints = geopandas.GeoDataFrame(footprints, geometry='footprint_geometry')
-        footprints.crs = crs
-        footprints.geometry = footprints.footprint_geometry
+            # For the columns that were in common between CUMINDEX.TAB and ODE REST API
+            # remove the ODE ones and keep the ones from CUMINDEX.TAB
+            chunk_footprints = chunk_footprints.loc[:,
+                         [col for col in chunk_footprints.columns if not col.endswith('_ode')]
+                         ]
+            chunk_footprints = chunk_footprints.apply(to_numeric_or_date)
 
-        # Upcast from shapely LineString to shapely Polygon
-        def polygonize(geom):
-            try:
-                return Polygon(geom)
-            except NotImplementedError:
-                print(f'Problem geometry: {geom} dropped')
-                return None
+            crs = projections[projection]
+            if projection == 'ec':
+                # Use IAU2000:30101
+                crs = '+proj=longlat +a=1737400 +b=1737400 +no_defs'
+                chunk_footprints.footprint_geometry = chunk_footprints.footprint_geometry.apply(wkt.loads)
+            elif projection == 'sp':
+                # Use IAU2000:30120
+                crs = '+proj=stere +lat_0=-90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs'
+                chunk_footprints.footprint_geometry = chunk_footprints.footprint_sp_geometry.apply(wkt.loads)
+            elif projection == 'np':
+                # Use IAU2000:30118
+                crs = '+proj=stere +lat_0=90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs'
+                chunk_footprints.footprint_geometry = chunk_footprints.footprint_np_geometry.apply(wkt.loads)
 
-        footprints.footprint_geometry = footprints.footprint_geometry.apply(
-            polygonize
-        )
-        footprints.crs = '+proj=longlat +a=1737400 +b=1737400 +no_defs'
-        return footprints.dropna()
+            chunk_footprints = geopandas.GeoDataFrame(chunk_footprints, geometry='footprint_geometry')
+            chunk_footprints.crs = crs
+            chunk_footprints.geometry = chunk_footprints.footprint_geometry
+
+            # Upcast from shapely LineString to shapely Polygon
+            def polygonize(geom):
+                if geom.geom_type == 'GeometryCollection':
+                    try:
+                        return MultiPolygon(geom)
+                    except TypeError:
+                        print(f'Problem geometry: {geom} dropped')
+                        return None
+                else:
+                    try:
+                        return Polygon(geom)
+                    except NotImplementedError:
+                        print(f'Problem geometry: {geom} dropped')
+                        return None
+
+            chunk_footprints.footprint_geometry = chunk_footprints.footprint_geometry.apply(
+                polygonize
+            )
+            chunk_footprints.crs = '+proj=longlat +a=1737400 +b=1737400 +no_defs'
+            filtered.append(chunk_footprints)
+        return pandas.concat(filtered).dropna()
 
     def date_range(self):
         return self.results.start_time.min(), self.results.stop_time.max()
@@ -484,7 +495,14 @@ def bounding_box(*, west: float, east: float, south: float, north: float, plot: 
     search_poly_shapely = geom_helpers.corners_to_quadrilateral(west, east, south, north, lonC0=True)
     imgs = ImageSearch(polygon=wkt.dumps(search_poly_shapely))
     pairset = StereoPairSet(imgs)
-    filtered_pairset = pairset.filter_sun_geometry().filter_small_overlaps()
+    if verbose:
+        print(f"found {len(pairset.pairs.index)} pairs.")
+    filtered_pairset = pairset.filter_sun_geometry()
+    if verbose:
+        print(f"found {len(filtered_pairset.pairs.index)} pairs after filtering out incompatible sun geometry.")
+    filtered_pairset = filtered_pairset.filter_small_overlaps()
+    if verbose:
+        print(f"found {len(filtered_pairset.pairs.index)} pairs after filtering out insufficient overlaps.")
     if find_covering:
         search_poly_shapely = wkt.loads(imgs.search_poly)
         filtered_pairset.pairs, stats = geom_helpers.covering_set_search(

--- a/src/moon/nacpl/find_stereo_pairs.py
+++ b/src/moon/nacpl/find_stereo_pairs.py
@@ -7,7 +7,10 @@ Aaron Curtis
 # TODO check that none of the filters modify self.pairs when inplace is False
 # TODO add type hinting
 # TODO make addition of inplace parameter into a decorator
+import itertools
+from typing import Iterator, Tuple
 
+from geopandas import GeoDataFrame
 
 from nacpl import geom_helpers, load_nac_metadata
 from shapely.geometry import Polygon, LineString, MultiPolygon
@@ -16,21 +19,19 @@ import geopandas, pandas
 import re
 import numpy
 import urllib
+import tqdm
 import json
 
 projections = {
     # IAU2000:30101
-    'ec': '+proj=longlat +a=1737400 +b=1737400 +no_defs',
+    "ec": "+proj=longlat +a=1737400 +b=1737400 +no_defs",
     # IAU2000:30118
-    'np': '+proj=stere +lat_0=90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs',
+    "np": "+proj=stere +lat_0=90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs",
     # Use IAU2000:30120
-    'sp': '+proj=stere +lat_0=-90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs'
+    "sp": "+proj=stere +lat_0=-90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs",
 }
 
 pandas.options.mode.chained_assignment = None
-
-lblfilepath = r'/INDEX.LBL'
-indfilepath = r'/CUMINDEX.TAB'
 
 
 def nac_url_to_id(url: str) -> str:
@@ -42,31 +43,31 @@ def nac_url_to_id(url: str) -> str:
 
     :return: the Product Id
     """
-    prod_id = re.findall('M\d*?[LR]', url)
+    prod_id = re.findall("M\d*?[LR]", url)
     assert len(prod_id) == 1
     return prod_id[0]
 
 
 def to_numeric_or_date(series):
     try:
-        return pandas.to_numeric(series, errors='ignore')
+        return pandas.to_numeric(series, errors="ignore")
     except ValueError:
-        return pandas.to_datetime(series, errors='ignore')
+        return pandas.to_datetime(series, errors="ignore")
 
 
 def both_in_range(prop, minimum, maximum, dataframe):
     bool_series = (
-            (dataframe[prop + '_1'] > minimum) &
-            (dataframe[prop + '_1'] < maximum) &
-            (dataframe[prop + '_2'] > minimum) &
-            (dataframe[prop + '_2'] < maximum)
+        (dataframe[prop + "_1"] > minimum)
+        & (dataframe[prop + "_1"] < maximum)
+        & (dataframe[prop + "_2"] > minimum)
+        & (dataframe[prop + "_2"] < maximum)
     )
     return bool_series
 
 
-def find_NACs_under_trajectory(csv_file_path: str,
-                               buffersize: float = 0.5,
-                               tolerance: float = 0.05) -> 'ImageSearch':
+def find_NACs_under_trajectory(
+    csv_file_path: str, buffersize: float = 0.5, tolerance: float = 0.05
+) -> "ImageSearch":
     """
     Finds NAC images to cover all points in csv_file
 
@@ -78,9 +79,11 @@ def find_NACs_under_trajectory(csv_file_path: str,
 
     # Convert from csv input file to WKT buffer polygon
     df = pandas.read_csv(csv_file_path, dtype=float)
-    points = df.loc[:, ['lon', 'lat']].values
+    points = df.loc[:, ["lon", "lat"]].values
     points = LineString(points)
-    pointzone = Polygon(points.buffer(buffersize).simplify(tolerance=tolerance).exterior)
+    pointzone = Polygon(
+        points.buffer(buffersize).simplify(tolerance=tolerance).exterior
+    )
     pointzone_wkt = wkt.dumps(pointzone, rounding_precision=3)
 
     # Instantiate an ImageSearch using that polygon
@@ -90,9 +93,9 @@ def find_NACs_under_trajectory(csv_file_path: str,
 def pair_id(pair):
     try:
         if pair.prod_id_1 < pair.prod_id_2:
-            return pair.prod_id_1 + 'xx' + pair.prod_id_2
+            return pair.prod_id_1 + "xx" + pair.prod_id_2
         else:
-            return pair.prod_id_2 + 'xx' + pair.prod_id_1
+            return pair.prod_id_2 + "xx" + pair.prod_id_1
     except TypeError:
         return None
 
@@ -109,93 +112,110 @@ class ImageSearch:
     def __init__(self, *args, **kwargs):
         self.search_args = args
         self.search_kwargs = kwargs
-        if 'polygon' in kwargs.keys():
-            self.search_poly = kwargs['polygon']
+        if "polygon" in kwargs.keys():
+            self.search_poly = kwargs["polygon"]
             self.results = self._search_from_poly(*args, **kwargs)
         else:
             self.results = self._search_from_bb(*args, **kwargs)
 
     @staticmethod
-    def _search_from_poly(polygon: str,
-                          indfilepath=indfilepath,  # TODO need better solution than hardcoding path to local files
-                          lblfilepath=lblfilepath,
-                          projection: str = 'ec',
-                          verbose: bool = False
-                          ):
+    def _search_from_poly(
+        polygon: str,
+        indfilepath,
+        lblfilepath,
+        projection: str = "ec",
+        verbose: bool = False,
+    ):
         """
         :param str projection: The projection to use. Should be 'ec' for lat / lon equidistant cylindrical, 'sp' for
-        south polar, 'np' for north polar. 
+        south polar, 'np' for north polar.
         """
         pointzone_urlstring = urllib.parse.quote_plus(polygon)
-        count_url = f'http://oderest.rsl.wustl.edu/live2/?query=products&target=moon&results=c&ihid=lro&iid=lroc&pt=EDRNAC&output=JSON&limit=1000&footprint={pointzone_urlstring}&loc=f'
+        count_url = f"http://oderest.rsl.wustl.edu/live2/?query=products&target=moon&results=c&ihid=lro&iid=lroc&pt=EDRNAC&output=JSON&limit=1000&footprint={pointzone_urlstring}&loc=f"
         count_resp = urllib.request.urlopen(count_url)
         count_resp = json.loads(count_resp.read())
-        count = int(count_resp['ODEResults']['Count'])
+        count = int(count_resp["ODEResults"]["Count"])
         if verbose:
-            print(f'Found {count} NAC footprints under the trajectory, will look up their product IDs now')
+            print(
+                f"Found {count} NAC footprints under the trajectory, will look up their product IDs now"
+            )
         # Not necessary to limit the footprint query using the count query, but default limit is 100 so need to set it to
         # something; might as well be the expected number of returned footprints
-        req_url = f'http://oderest.rsl.wustl.edu/live2/?query=products&target=moon&results=pm&ihid=lro&iid=lroc&pt=EDRNAC&output=JSON&limit={count}&footprint={pointzone_urlstring}&loc=f'
+        req_url = f"http://oderest.rsl.wustl.edu/live2/?query=products&target=moon&results=pm&ihid=lro&iid=lroc&pt=EDRNAC&output=JSON&limit={count}&footprint={pointzone_urlstring}&loc=f"
         resp = urllib.request.urlopen(req_url)
         resp = json.loads(resp.read())
         if verbose:
-            print(f'Looking in CUMINDEX.TAB for sun & spacecraft geometry info')
-        footprints = pandas.DataFrame(resp['ODEResults']['Products']['Product'])
+            print(f"Looking in CUMINDEX.TAB for sun & spacecraft geometry info")
+        footprints = pandas.DataFrame(resp["ODEResults"]["Products"]["Product"])
         # lowercase all column names for ease of joining from different APIs
         footprints.columns = [col.lower() for col in footprints.columns]
-        footprints.set_index('pdsid', inplace=True)
+        footprints.set_index("pdsid", inplace=True)
 
         filtered = []
-        chunks_metadata = load_nac_metadata.load_nac_index(indfilepath=indfilepath, lblfilepath=lblfilepath)
-        for chunk_metadata in chunks_metadata:  # iterate over chunks instead of loading all CSV into RAM
+        chunks_metadata = load_nac_metadata.load_nac_index(
+            indfilepath=indfilepath, lblfilepath=lblfilepath
+        )
+        for (
+            chunk_metadata
+        ) in chunks_metadata:  # iterate over chunks instead of loading all CSV into RAM
             chunk_metadata.product_id = chunk_metadata.product_id.apply(str.strip)
-            chunk_metadata.set_index('product_id', inplace=True)
-            chunk_footprints = footprints.join(chunk_metadata, how='inner', lsuffix='_ode', rsuffix='')
+            chunk_metadata.set_index("product_id", inplace=True)
+            chunk_footprints = footprints.join(
+                chunk_metadata, how="inner", lsuffix="_ode", rsuffix=""
+            )
 
             # For the columns that were in common between CUMINDEX.TAB and ODE REST API
             # remove the ODE ones and keep the ones from CUMINDEX.TAB
-            chunk_footprints = chunk_footprints.loc[:,
-                         [col for col in chunk_footprints.columns if not col.endswith('_ode')]
-                         ]
+            chunk_footprints = chunk_footprints.loc[
+                :, [col for col in chunk_footprints.columns if not col.endswith("_ode")]
+            ]
             chunk_footprints = chunk_footprints.apply(to_numeric_or_date)
 
             crs = projections[projection]
-            if projection == 'ec':
+            if projection == "ec":
                 # Use IAU2000:30101
-                crs = '+proj=longlat +a=1737400 +b=1737400 +no_defs'
-                chunk_footprints.footprint_geometry = chunk_footprints.footprint_geometry.apply(wkt.loads)
-            elif projection == 'sp':
+                crs = "+proj=longlat +a=1737400 +b=1737400 +no_defs"
+                chunk_footprints.footprint_geometry = (
+                    chunk_footprints.footprint_geometry.apply(wkt.loads)
+                )
+            elif projection == "sp":
                 # Use IAU2000:30120
-                crs = '+proj=stere +lat_0=-90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs'
-                chunk_footprints.footprint_geometry = chunk_footprints.footprint_sp_geometry.apply(wkt.loads)
-            elif projection == 'np':
+                crs = "+proj=stere +lat_0=-90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs"
+                chunk_footprints.footprint_geometry = (
+                    chunk_footprints.footprint_sp_geometry.apply(wkt.loads)
+                )
+            elif projection == "np":
                 # Use IAU2000:30118
-                crs = '+proj=stere +lat_0=90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs'
-                chunk_footprints.footprint_geometry = chunk_footprints.footprint_np_geometry.apply(wkt.loads)
+                crs = "+proj=stere +lat_0=90 +lon_0=0 +k=1 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs"
+                chunk_footprints.footprint_geometry = (
+                    chunk_footprints.footprint_np_geometry.apply(wkt.loads)
+                )
 
-            chunk_footprints = geopandas.GeoDataFrame(chunk_footprints, geometry='footprint_geometry')
+            chunk_footprints = geopandas.GeoDataFrame(
+                chunk_footprints, geometry="footprint_geometry"
+            )
             chunk_footprints.crs = crs
             chunk_footprints.geometry = chunk_footprints.footprint_geometry
 
             # Upcast from shapely LineString to shapely Polygon
             def polygonize(geom):
-                if geom.geom_type == 'GeometryCollection':
+                if geom.geom_type == "GeometryCollection":
                     try:
                         return MultiPolygon(geom)
                     except TypeError:
-                        print(f'Problem geometry: {geom} dropped')
+                        print(f"Problem geometry: {geom} dropped")
                         return None
                 else:
                     try:
                         return Polygon(geom)
                     except NotImplementedError:
-                        print(f'Problem geometry: {geom} dropped')
+                        print(f"Problem geometry: {geom} dropped")
                         return None
 
-            chunk_footprints.footprint_geometry = chunk_footprints.footprint_geometry.apply(
-                polygonize
+            chunk_footprints.footprint_geometry = (
+                chunk_footprints.footprint_geometry.apply(polygonize)
             )
-            chunk_footprints.crs = '+proj=longlat +a=1737400 +b=1737400 +no_defs'
+            chunk_footprints.crs = "+proj=longlat +a=1737400 +b=1737400 +no_defs"
             filtered.append(chunk_footprints)
         return pandas.concat(filtered).dropna()
 
@@ -207,8 +227,88 @@ class ImageSearch:
 
     def plot_overlaps(self):
         from matplotlib import pyplot
-        self.overlaps().plot(facecolor='none', edgecolor='k')
+
+        self.overlaps().plot(facecolor="none", edgecolor="k")
         pyplot.show()
+
+
+def pairs_iter_from_image_search(imagesearch: "ImageSearch") -> Iterator[GeoDataFrame]:
+    gdf: GeoDataFrame = imagesearch.results.dropna()
+    # Store index (product id) in column so that it's preserved in spatial join operation
+    gdf["prod_id"] = gdf.index
+
+    chunk_row_size = 100
+    chunks = [
+        gdf[i : i + chunk_row_size] for i in range(0, gdf.shape[0], chunk_row_size)
+    ]
+    for (chunk_1, chunk_2) in tqdm.tqdm(
+        itertools.product(chunks, chunks), total=(len(chunks) ** 2.0)
+    ):
+        pairs = geopandas.overlay(chunk_1, chunk_2, how="union", keep_geom_type=True)
+        # If we're in lat lon, then need to convert to meters before calculating area
+        pairs_eqc = pairs.to_crs(
+            "+proj=eqc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs"
+        )
+        pairs[
+            "area_m2"
+        ] = (
+            pairs_eqc.area
+        )  # Store area as column before sorting (could use key fn instead...)
+        pairs.sort_values("area_m2", ascending=False, inplace=True)
+
+        pairs = pairs[pairs.loc[:, "prod_id_1"] != pairs.loc[:, "prod_id_2"]]
+        # Remove flipped-pair-order pairs (e.g. M1234LxxM4567L where M4567LxxM1234L exists in the same dataset)
+        # First, create a column of pair ids, always with the low number first
+        pairs.loc[:, "pair_id"] = pairs.apply(pair_id, axis=1)
+        pairs.drop_duplicates(subset="pair_id", inplace=True)
+        pairs.set_index("pair_id", inplace=True)
+        yield pairs
+
+
+def filter_sun_geometry(
+    pairs: GeoDataFrame,
+    max_sun_azimuth_ground_difference: float = 20,
+    max_incidence_angle_difference: float = 20,
+    incidence_range: Tuple[float, float] = (10.0, 86.0),
+) -> GeoDataFrame:
+    """
+    Removes stereo pairs which have incompatible sun geometry.
+    :param max_sun_azimuth_ground_difference: Maximum sun azimuth difference, in degrees.
+    :param max_incidence_angle_difference: Maximum sun incidence angle difference, in degrees.
+    :return: StereoPairSet of pairs with bad sun geometry pairs removed.
+    """
+    big_incidence_diff = (
+        numpy.abs(pairs.incidence_angle_1 - pairs.incidence_angle_2)
+        < max_incidence_angle_difference
+    )
+    sub_solar_ground_az_1 = pairs.north_azimuth_1 - pairs.sub_solar_azimuth_1
+    sub_solar_ground_az_2 = pairs.north_azimuth_2 - pairs.sub_solar_azimuth_2
+    sub_solar_ground_az_diff = numpy.abs(sub_solar_ground_az_1 - sub_solar_ground_az_2)
+    big_sunaz_diff = sub_solar_ground_az_diff < max_sun_azimuth_ground_difference
+    incidence1_within_range_low = incidence_range[0] <= pairs.incidence_angle_1
+    incidence1_within_range_high = pairs.incidence_angle_1 <= incidence_range[1]
+    incidence2_within_range_low = incidence_range[0] <= pairs.incidence_angle_2
+    incidence2_within_range_high = pairs.incidence_angle_2 <= incidence_range[1]
+    return pairs[
+        big_incidence_diff
+        & big_sunaz_diff
+        & incidence1_within_range_low
+        & incidence1_within_range_high
+        & incidence2_within_range_low
+        & incidence2_within_range_high
+    ]
+
+
+def filter_small_overlaps(
+    pairs: GeoDataFrame,
+    min_area: float = 50000000,
+) -> GeoDataFrame:
+    """
+    Removes stereo pairs with insufficient overlap area.
+    :param min_area: Minimum overlap area, in square meters.
+    :return: StereoPairSet with small-overlap pairs removed.
+    """
+    return pairs[pairs.area_m2 > min_area]
 
 
 class StereoPairSet:
@@ -243,42 +343,72 @@ class StereoPairSet:
 
     """
 
-    def __init__(self, imagesearch: ImageSearch = None, pairs=None, projection: str = 'ec'):
+    def __init__(
+        self, imagesearch: ImageSearch = None, pairs=None, projection: str = "ec"
+    ):
         # If StereoPairSet is instantiated with another StereoPairSet, copy the pairs
         if pairs is not None:
             self.pairs = pairs
         elif imagesearch is not None:
-            gdf = imagesearch.results.dropna()
-            gdf[
-                'prod_id'] = gdf.index  # Store index (product id) in column so that it's preserved in spatial join operation
-            self.pairs = geopandas.overlay(gdf, gdf, how='union', keep_geom_type=True)
+            gdf: GeoDataFrame = imagesearch.results.dropna()
+            # Store index (product id) in column so that it's preserved in spatial join operation
+            gdf["prod_id"] = gdf.index
+
+            chunk_row_size = 100
+            chunks = [
+                gdf[i : i + chunk_row_size]
+                for i in range(0, gdf.shape[0], chunk_row_size)
+            ]
+            chunks_pairs = []
+            for (chunk_1, chunk_2) in tqdm.tqdm(
+                itertools.product(chunks, chunks), total=(len(chunks) ** 2.0)
+            ):
+                chunks_pairs.append(
+                    geopandas.overlay(
+                        chunk_1, chunk_2, how="union", keep_geom_type=True
+                    )
+                )
+
+            self.pairs = pandas.concat(chunks_pairs)
+
+            # self.pairs = geopandas.overlay(gdf, gdf, how='union', keep_geom_type=True)
             # If we're in lat lon, then need to convert to meters before calculating area
-            if projection == 'ec':
+            if projection == "ec":
                 pairs_eqc = self.pairs.to_crs(
                     "+proj=eqc +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +a=1737400 +b=1737400 +units=m +no_defs"
                 )
-            self.pairs['area_m2'] = pairs_eqc.area  # Store area as column before sorting (could use key fn instead...)
-            self.pairs.sort_values('area_m2', ascending=False, inplace=True)
-            self.filter_unique(
-                inplace=True)  # TODO pair_id is created inside this method call -- maybe not the best place for that
-            self.pairs.set_index('pair_id', inplace=True)
+            self.pairs[
+                "area_m2"
+            ] = (
+                pairs_eqc.area
+            )  # Store area as column before sorting (could use key fn instead...)
+            self.pairs.sort_values("area_m2", ascending=False, inplace=True)
+            # TODO pair_id is created inside this method call -- maybe not the best place for that
+            self.filter_unique(inplace=True)
+            self.pairs.set_index("pair_id", inplace=True)
             self.bb_covering_pairs = None
         else:
-            raise TypeError("Need either imagesearch or pairs argument to instantiate StereoPairSet")
+            raise TypeError(
+                "Need either imagesearch or pairs argument to instantiate StereoPairSet"
+            )
 
-    def filter_new_pairs(self, since, inplace: bool = True) -> 'StereoPairSet':
+    def filter_new_pairs(self, since, inplace: bool = True) -> "StereoPairSet":
         """
         Finds stereo pairs that have recently become available due to addition of new data.
         :param since: Any date / time format accepted as a pandas indexer
         :param inplace: Replace .pairs of this StereoPairSet instance with the filtered version
         :return: StereoPairSet of stereo pairs where at least one of the images is newer than since
         """
-        filtered_pairs = self.pairs[(self.pairs.start_time_1 > since) | (self.pairs.start_time_2 > since)]
+        filtered_pairs = self.pairs[
+            (self.pairs.start_time_1 > since) | (self.pairs.start_time_2 > since)
+        ]
         if inplace:
             self.pairs = filtered_pairs
         return StereoPairSet(pairs=filtered_pairs)
 
-    def filter_date_range(self, startime, endtime, inplace: bool = True) -> 'StereoPairSet':
+    def filter_date_range(
+        self, startime, endtime, inplace: bool = True
+    ) -> "StereoPairSet":
         """
         Finds stereo pairs where both images were acquired after startime and before endtime.
         :param startime: Any date / time representation accepted by Pandas for slicing
@@ -286,12 +416,16 @@ class StereoPairSet:
         :param inplace:
         :return: StereoPairSet of stereo pairs where both images were acquired between startime and endtime.
         """
-        filtered_pairs = both_in_range('start_time', minimum=startime, maximum=endtime, dataframe=self.pairs)
+        filtered_pairs = both_in_range(
+            "start_time", minimum=startime, maximum=endtime, dataframe=self.pairs
+        )
         if inplace:
             filtered_pairs = self.pairs[filtered_pairs]
         return StereoPairSet(pairs=filtered_pairs)
 
-    def filter_sufficient_convergence(self, min_convergence: float = 2, inplace: bool = True) -> 'StereoPairSet':
+    def filter_sufficient_convergence(
+        self, min_convergence: float = 2, inplace: bool = True
+    ) -> "StereoPairSet":
         """
         Removes stereo pairs which have an emission angle difference of less than min_convergence degrees.
         :param inplace: Replace .pairs of this StereoPairSet instance with the filtered version
@@ -299,14 +433,19 @@ class StereoPairSet:
         :return: StereoPairSet with pairs that have insufficient convergence removed.
         """
         filtered_pairs = self.pairs[
-            numpy.abs(self.pairs.emission_angle_1 - self.pairs.emission_angle_2) > min_convergence]
+            numpy.abs(self.pairs.emission_angle_1 - self.pairs.emission_angle_2)
+            > min_convergence
+        ]
         if inplace:
             self.pairs = filtered_pairs
         return StereoPairSet(pairs=filtered_pairs)
 
-    def filter_sun_geometry(self, max_sun_azimuth_ground_difference: float = 20,
-                            max_incidence_angle_difference: float = 20,
-                            inplace: bool = True) -> 'StereoPairSet':
+    def filter_sun_geometry(
+        self,
+        max_sun_azimuth_ground_difference: float = 20,
+        max_incidence_angle_difference: float = 20,
+        inplace: bool = True,
+    ) -> "StereoPairSet":
         """
         Removes stereo pairs which have incompatible sun geometry.
         :param max_sun_azimuth_ground_difference: Maximum sun azimuth difference, in degrees.
@@ -314,18 +453,28 @@ class StereoPairSet:
         :param inplace: Replace .pairs of this StereoPairSet instance with the filtered version
         :return: StereoPairSet of pairs with bad sun geometry pairs removed.
         """
-        big_incidence_diff = numpy.abs(
-            self.pairs.incidence_angle_1 - self.pairs.incidence_angle_2) < max_incidence_angle_difference
-        sub_solar_ground_az_1 = self.pairs.north_azimuth_1 - self.pairs.sub_solar_azimuth_1
-        sub_solar_ground_az_2 = self.pairs.north_azimuth_2 - self.pairs.sub_solar_azimuth_2
-        sub_solar_ground_az_diff = numpy.abs(sub_solar_ground_az_1 - sub_solar_ground_az_2)
+        big_incidence_diff = (
+            numpy.abs(self.pairs.incidence_angle_1 - self.pairs.incidence_angle_2)
+            < max_incidence_angle_difference
+        )
+        sub_solar_ground_az_1 = (
+            self.pairs.north_azimuth_1 - self.pairs.sub_solar_azimuth_1
+        )
+        sub_solar_ground_az_2 = (
+            self.pairs.north_azimuth_2 - self.pairs.sub_solar_azimuth_2
+        )
+        sub_solar_ground_az_diff = numpy.abs(
+            sub_solar_ground_az_1 - sub_solar_ground_az_2
+        )
         big_sunaz_diff = sub_solar_ground_az_diff < max_sun_azimuth_ground_difference
         filtered_pairs = self.pairs[big_incidence_diff & big_sunaz_diff]
         if inplace:
             self.pairs = filtered_pairs
         return StereoPairSet(pairs=filtered_pairs)
 
-    def filter_small_overlaps(self, min_area: float = 50000000, inplace: bool = True) -> 'StereoPairSet':
+    def filter_small_overlaps(
+        self, min_area: float = 50000000, inplace: bool = True
+    ) -> "StereoPairSet":
         """
         Removes stereo pairs with insufficient overlap area.
         :param min_area: Minimum overlap area, in square meters.
@@ -337,30 +486,36 @@ class StereoPairSet:
             self.pairs = filtered_pairs
         return StereoPairSet(pairs=filtered_pairs)
 
-    def filter_unique(self, inplace: bool = True) -> 'StereoPairSet':
+    def filter_unique(self, inplace: bool = True) -> "StereoPairSet":
         """
         Remove self-pairs (e.g. M1234LxxM1234L)
         :param inplace: Replace .pairs of this StereoPairSet instance with the filtered version
         :return: StereoPairSet with self-pairs removed.
         """
-        filtered_pairs = self.pairs[self.pairs.loc[:, 'prod_id_1'] != self.pairs.loc[:, 'prod_id_2']]
+        filtered_pairs = self.pairs[
+            self.pairs.loc[:, "prod_id_1"] != self.pairs.loc[:, "prod_id_2"]
+        ]
         # Remove flipped-pair-order pairs (e.g. M1234LxxM4567L where M4567LxxM1234L exists in the same dataset)
         # First, create a column of pair ids, always with the low number first
-        filtered_pairs.loc[:, 'pair_id'] = filtered_pairs.apply(pair_id, axis=1)
-        filtered_pairs.drop_duplicates(subset='pair_id', inplace=True)
+        filtered_pairs.loc[:, "pair_id"] = filtered_pairs.apply(pair_id, axis=1)
+        filtered_pairs.drop_duplicates(subset="pair_id", inplace=True)
         if inplace:
             self.pairs = filtered_pairs
         return StereoPairSet(pairs=filtered_pairs)
 
-    def filter_incidence(self, inplace: bool = True) -> 'StereoPairSet':
+    def filter_incidence(self, inplace: bool = True) -> "StereoPairSet":
         """
         Remove pair unless both images have 40 < incidence angle < 65
         :param inplace: Replace .pairs of this StereoPairSet instance with the filtered version
         :return: StereoPairSet with bad incidence angle pairs removed.
         """
-        filtered_pairs = self.pairs.loc[both_in_range('incidence_angle', 40, 65, self.pairs), :]
+        filtered_pairs = self.pairs.loc[
+            both_in_range("incidence_angle", 40, 65, self.pairs), :
+        ]
         # Remove pair unless both images have emission angle < 45
-        filtered_pairs = filtered_pairs.loc[both_in_range('emission_angle', 40, 65, filtered_pairs), :]
+        filtered_pairs = filtered_pairs.loc[
+            both_in_range("emission_angle", 40, 65, filtered_pairs), :
+        ]
         # TODO maybe add phase angle
         if inplace:
             self.pairs = filtered_pairs
@@ -376,33 +531,55 @@ class StereoPairSet:
         """
         pairs = self.pairs
         metrics = pandas.DataFrame(
-            columns=['Resolution ratio', 'Parallax/height ratio', 'Shadow tip distance'],
-            index=pairs.index
+            columns=[
+                "Resolution ratio",
+                "Parallax/height ratio",
+                "Shadow tip distance",
+            ],
+            index=pairs.index,
         )
 
-        resolutions = pairs.loc[:, ['resolution_1',
-                                    'resolution_2']].to_numpy()  # Converting to numpy for sorting because Pandas can't do this kind of sort
+        resolutions = pairs.loc[
+            :, ["resolution_1", "resolution_2"]
+        ].to_numpy()  # Converting to numpy for sorting because Pandas can't do this kind of sort
         resolutions.sort()  # numpy does things inplace
-        metrics['Resolution ratio'] = resolutions[:, 1] / resolutions[:, 0]
+        metrics["Resolution ratio"] = resolutions[:, 1] / resolutions[:, 0]
 
-        px1 = - numpy.tan(pairs.emission_angle_1) * numpy.cos(pairs.north_azimuth_1)  # parallax x, image 1
-        py1 = numpy.tan(pairs.emission_angle_1) * numpy.sin(pairs.north_azimuth_1)  # parallax y, image 1
-        px2 = - numpy.tan(pairs.emission_angle_2) * numpy.cos(pairs.north_azimuth_2)  # parallax x, image 2
-        py2 = numpy.tan(pairs.emission_angle_2) * numpy.sin(pairs.north_azimuth_2)  # parallax y, image 2
-        metrics['Parallax/height ratio'] = ((px1 - px2) ** 2 + (
-                py1 - py2) ** 2) ** 0.5  # related to convergence angle ("stereo strength")
+        px1 = -numpy.tan(pairs.emission_angle_1) * numpy.cos(
+            pairs.north_azimuth_1
+        )  # parallax x, image 1
+        py1 = numpy.tan(pairs.emission_angle_1) * numpy.sin(
+            pairs.north_azimuth_1
+        )  # parallax y, image 1
+        px2 = -numpy.tan(pairs.emission_angle_2) * numpy.cos(
+            pairs.north_azimuth_2
+        )  # parallax x, image 2
+        py2 = numpy.tan(pairs.emission_angle_2) * numpy.sin(
+            pairs.north_azimuth_2
+        )  # parallax y, image 2
+        metrics["Parallax/height ratio"] = (
+            (px1 - px2) ** 2 + (py1 - py2) ** 2
+        ) ** 0.5  # related to convergence angle ("stereo strength")
 
-        shx1 = - numpy.tan(pairs.incidence_angle_1) * numpy.cos(pairs.sub_solar_azimuth_1)
+        shx1 = -numpy.tan(pairs.incidence_angle_1) * numpy.cos(
+            pairs.sub_solar_azimuth_1
+        )
         shy1 = numpy.tan(pairs.incidence_angle_1) * numpy.sin(pairs.sub_solar_azimuth_1)
-        shx2 = - numpy.tan(pairs.incidence_angle_2) * numpy.cos(pairs.sub_solar_azimuth_2)
+        shx2 = -numpy.tan(pairs.incidence_angle_2) * numpy.cos(
+            pairs.sub_solar_azimuth_2
+        )
         shy2 = numpy.tan(pairs.incidence_angle_2) * numpy.sin(pairs.sub_solar_azimuth_2)
-        metrics['Shadow tip distance'] = ((shx1 - shx2) ** 2 + (
-                shy1 - shy2) ** 2) ** 0.5  # Shadow-tip distance (measure of illumination compatibility)
+        metrics["Shadow tip distance"] = (
+            (shx1 - shx2) ** 2 + (shy1 - shy2) ** 2
+        ) ** 0.5  # Shadow-tip distance (measure of illumination compatibility)
 
         limits = {
-            'Resolution ratio': (0, 4),  # Paper recommends
-            'Parallax/height ratio': (0.1, 1),  # TODO units?
-            'Shadow tip distance': (0, 100)  # in deg, TODO check if we need to convert from rad
+            "Resolution ratio": (0, 4),  # Paper recommends
+            "Parallax/height ratio": (0.1, 1),  # TODO units?
+            "Shadow tip distance": (
+                0,
+                100,
+            ),  # in deg, TODO check if we need to convert from rad
         }
 
         normalized_metrics = {
@@ -410,8 +587,10 @@ class StereoPairSet:
             for metric, value in metrics.items()
         }
 
-        metrics['Overall quality'] = pandas.DataFrame(normalized_metrics).prod(axis='columns')
-        metrics['Area m2'] = pairs.area_m2
+        metrics["Overall quality"] = pandas.DataFrame(normalized_metrics).prod(
+            axis="columns"
+        )
+        metrics["Area m2"] = pairs.area_m2
 
         return metrics
 
@@ -425,32 +604,39 @@ class StereoPairSet:
         # Convert from WKT string to shapely
         polygon = wkt.loads(polygon)
         west, south, east, north = polygon.bounds
-        self.find_covering_set(west=west,
-                               east=east,
-                               south=south,
-                               north=north,
-                               clip_to_polygon=polygon,
-                               grid_n_initial=75,
-                               grid_n_limit=77,
-                               grid_n_step=2,
-                               plot=plot)
+        self.find_covering_set(
+            west=west,
+            east=east,
+            south=south,
+            north=north,
+            clip_to_polygon=polygon,
+            grid_n_initial=75,
+            grid_n_limit=77,
+            grid_n_step=2,
+            plot=plot,
+        )
 
     def plot(self) -> None:
         from matplotlib import pyplot
-        self.pairs.plot(edgecolor='grey')
+
+        self.pairs.plot(edgecolor="grey")
         pyplot.show()
 
     def pairs_json(self) -> str:
         pair_ids = self.pairs.index.drop_duplicates()
         pairs_dict = [
-            {'left': f'{pair_id.split("xx")[0]}',
-             'right': f'{pair_id.split("xx")[1]}'}
+            {"left": f'{pair_id.split("xx")[0]}', "right": f'{pair_id.split("xx")[1]}'}
             for pair_id in pair_ids
         ]
         return json.dumps(list(pairs_dict))
 
+    def pairs_ids_list(self) -> list[str]:
+        return [p_id for p_id in self.pairs.index.drop_duplicates()]
 
-def trajectory(trajectory_csv: str, plot: bool = False, find_covering: bool = False, verbose=False) -> 'StereoPairSet':
+
+def trajectory(
+    trajectory_csv: str, plot: bool = False, find_covering: bool = False, verbose=False
+) -> "StereoPairSet":
     """
     Find stereo pairs beneath a trajectory of points
 
@@ -470,53 +656,94 @@ def trajectory(trajectory_csv: str, plot: bool = False, find_covering: bool = Fa
             full_poly_set=filtered_pairset.pairs,
             search_poly=search_poly_shapely,
             plot=plot,
-            verbose=False
+            verbose=False,
         )
     print(filtered_pairset.pairs_json())
     return filtered_pairset
 
 
-def bounding_box(*, west: float, east: float, south: float, north: float, plot: bool = False,
-                 find_covering: bool = True,
-                 return_pairset: bool = False, verbose=False) -> 'StereoPairSet':
+def bounding_box(
+    *,
+    west: float,
+    east: float,
+    south: float,
+    north: float,
+    indfilepath,
+    lblfilepath,
+    plot: bool = False,
+    find_covering: bool = True,
+    return_pairset: bool = False,
+    verbose=False,
+    max_pairs: int = 1000,
+    miss_limit: int = 20,
+    incidence_range_low: float = 10.0,
+    incidence_range_high: float = 86.0,
+) -> "StereoPairSet":
     """
     Find stereo pairs that fill a given bounding box
-    
-    # :param west: Western limit of the box, in -180 to 180 longitude, positive east
-    # :param east: Eastern limit of the box, in -180 to 180 longitude, positive east
-    # :param south: Southern limit of the box, in -90 to 90 latitude, positive north
-    # :param north: Northern limit of the box, in -90 to 90 latitude, positive north
+
+    :param west: Western limit of the box, in -180 to 180 longitude, positive east
+    :param east: Eastern limit of the box, in -180 to 180 longitude, positive east
+    :param south: Southern limit of the box, in -90 to 90 latitude, positive north
+    :param north: Northern limit of the box, in -90 to 90 latitude, positive north
     :param plot: Whether to plot the footprints of the selected images
     :param find_covering: Whether to search for a minimal set of pairs covering the bounding box. Otherwise, outputs all
     pairs that have good sun and spacecraft geometry.
     :return: A StereoPairSet
     """
 
-    search_poly_shapely = geom_helpers.corners_to_quadrilateral(west, east, south, north, lonC0=True)
-    imgs = ImageSearch(polygon=wkt.dumps(search_poly_shapely))
-    pairset = StereoPairSet(imgs)
+    search_poly_shapely = geom_helpers.corners_to_quadrilateral(
+        west, east, south, north, lonC0=True
+    )
+    imgs = ImageSearch(
+        polygon=wkt.dumps(search_poly_shapely),
+        indfilepath=indfilepath,
+        lblfilepath=lblfilepath,
+    )
     if verbose:
-        print(f"found {len(pairset.pairs.index)} pairs.")
-    filtered_pairset = pairset.filter_sun_geometry()
+        print(f"found {len(imgs.results)} images.")
+
+    filtered_pairs = []
+    filtered_pairs_count = 0
+    for pairs_chunk in pairs_iter_from_image_search(imgs):
+        filtered_chunk_pairs = filter_small_overlaps(
+            filter_sun_geometry(
+                pairs_chunk, incidence_range=(incidence_range_low, incidence_range_high)
+            )
+        )
+        filtered_pairs.append(filtered_chunk_pairs)
+        filtered_pairs_count += len(filtered_chunk_pairs)
+        if filtered_pairs_count > max_pairs:
+            print(f"found {filtered_pairs_count} pairs > --max-pairs={max_pairs}")
+            break
+
+    pairs = pandas.concat(filtered_pairs)
     if verbose:
-        print(f"found {len(filtered_pairset.pairs.index)} pairs after filtering out incompatible sun geometry.")
-    filtered_pairset = filtered_pairset.filter_small_overlaps()
+        print(f"found {len(pairs)} pairs")
     if verbose:
-        print(f"found {len(filtered_pairset.pairs.index)} pairs after filtering out insufficient overlaps.")
+        print(f"sorting pairs according to area...")
+    pairs.sort_values("area_m2", ascending=False, inplace=True)
+    if verbose:
+        print(f"sorting pairs according to area...done")
+    filtered_pairset = StereoPairSet(pairs=pairs)
+    if verbose:
+        print(f"found {len(filtered_pairset.pairs.index)} pairs.")
     if find_covering:
         search_poly_shapely = wkt.loads(imgs.search_poly)
         filtered_pairset.pairs, stats = geom_helpers.covering_set_search(
             full_poly_set=filtered_pairset.pairs,
             search_poly=search_poly_shapely,
             plot=plot,
-            verbose=False
+            verbose=verbose,
+            miss_limit=miss_limit,
         )
+        print(f"coverage stats: {stats}")
     print(filtered_pairset.pairs_json())
     if return_pairset:
         return filtered_pairset
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import clize, json
 
     clize.run(bounding_box, alt=trajectory)

--- a/src/moon/nacpl/find_stereo_pairs.py
+++ b/src/moon/nacpl/find_stereo_pairs.py
@@ -630,9 +630,6 @@ class StereoPairSet:
         ]
         return json.dumps(list(pairs_dict))
 
-    def pairs_ids_list(self) -> list[str]:
-        return [p_id for p_id in self.pairs.index.drop_duplicates()]
-
 
 def trajectory(
     trajectory_csv: str, plot: bool = False, find_covering: bool = False, verbose=False
@@ -670,6 +667,7 @@ def bounding_box(
     north: float,
     indfilepath,
     lblfilepath,
+    json_output=None,
     plot: bool = False,
     find_covering: bool = True,
     return_pairset: bool = False,
@@ -713,7 +711,7 @@ def bounding_box(
         )
         filtered_pairs.append(filtered_chunk_pairs)
         filtered_pairs_count += len(filtered_chunk_pairs)
-        if filtered_pairs_count > max_pairs:
+        if filtered_pairs_count > max_pairs and verbose:
             print(f"found {filtered_pairs_count} pairs > --max-pairs={max_pairs}")
             break
 
@@ -737,8 +735,12 @@ def bounding_box(
             verbose=verbose,
             miss_limit=miss_limit,
         )
-        print(f"coverage stats: {stats}")
+        if verbose:
+            print(f"coverage stats: {stats}")
     print(filtered_pairset.pairs_json())
+    if json_output is not None:
+        with open(json_output, "w+") as json_file:
+            json_file.write(filtered_pairset.pairs_json())
     if return_pairset:
         return filtered_pairset
 

--- a/src/moon/nacpl/load_nac_metadata.py
+++ b/src/moon/nacpl/load_nac_metadata.py
@@ -11,7 +11,7 @@ lblfilepath = r'/INDEX.LBL'
 indfilepath = r'/CUMINDEX.TAB'
 footprintfileglob = r'/moon_lro_lroc_edrnac_ga/*.shp'
 
-CHUNK_SIZE = 5000  # lines
+CHUNK_SIZE = 100000  # lines
 
 
 def load_nac_index(lblfilepath=lblfilepath, indfilepath=indfilepath, chunksize=CHUNK_SIZE) -> typing.Union[

--- a/src/moon/nacpl/load_nac_metadata.py
+++ b/src/moon/nacpl/load_nac_metadata.py
@@ -2,13 +2,20 @@
 Loads LROC NAC metadata and footprints from local
 """
 
+import typing
+from pandas.io.parsers import TextFileReader
+
 # Read column descriptions from CUMINDEX.LBL
 # this was downloaded from http://lroc.sese.asu.edu/data/LRO-L-LROC-2-EDR-V1.0/LROLRC_0040C/INDEX/
 lblfilepath = r'/INDEX.LBL'
 indfilepath = r'/CUMINDEX.TAB'
 footprintfileglob = r'/moon_lro_lroc_edrnac_ga/*.shp'
 
-def load_nac_index(lblfilepath=lblfilepath, indfilepath=indfilepath):
+CHUNK_SIZE = 5000  # lines
+
+
+def load_nac_index(lblfilepath=lblfilepath, indfilepath=indfilepath, chunksize=CHUNK_SIZE) -> typing.Union[
+    TextFileReader]:
     import pandas
     import pvl
     with open(lblfilepath, 'r') as lblfile:
@@ -18,8 +25,9 @@ def load_nac_index(lblfilepath=lblfilepath, indfilepath=indfilepath):
         col_pvl = lblpvl['INDEX_TABLE'].getlist('COLUMN')
         col_list = [col['NAME'].lower() for col in col_pvl]
 
-        nac_index = pandas.read_csv(indfilepath, header=None, names=col_list)
+        nac_index = pandas.read_csv(indfilepath, header=None, names=col_list, chunksize=chunksize)
     return nac_index
+
 
 def load_nac_footprints(footprintfileglob=footprintfileglob):
     import geopandas

--- a/src/moon/nacpl/random_point.py
+++ b/src/moon/nacpl/random_point.py
@@ -1,0 +1,24 @@
+import random
+from shapely.affinity import affine_transform
+from shapely.geometry import Point
+from shapely.ops import triangulate
+
+# https://codereview.stackexchange.com/questions/69833/generate-sample-coordinates-inside-a-polygon#comment127620_69839
+
+def random_points_in_polygon(polygon, k):
+    "Return list of k points chosen uniformly at random inside the polygon."
+    areas = []
+    transforms = []
+    for t in triangulate(polygon):
+        areas.append(t.area)
+        (x0, y0), (x1, y1), (x2, y2), _ = t.exterior.coords
+        transforms.append([x1 - x0, x2 - x0, y2 - y0, y1 - y0, x0, y0])
+    points = []
+    for transform in random.choices(transforms, weights=areas, k=k):
+        x, y = [random.random() for _ in range(2)]
+        if x + y > 1:
+            p = Point(1 - x, 1 - y)
+        else:
+            p = Point(x, y)
+        points.append(affine_transform(p, transform))
+    return points


### PR DESCRIPTION
## Motivation

The purpose of this PR is to discuss a few possible optimizations (RAM usage, coverage), additional parameters.

> **This PR is probably not mature enough to be merged**.
> **It probably contains bugs and breaks some existing API**.

@foobarbecue feel free to cherry-pick what you deem useful ;)

## RAM optimizations

### Parsing NAC index

* This PR adds chunks processing of the NAC index
> it keeps memory usage low while parsing the NAC index

It works thanks to the `chunksize` parameter provided by `pandas.read_csv`
```python
        # read nac_index as chunks instead of reading everything at once in memory
        nac_index = pandas.read_csv(indfilepath, header=None, names=col_list, chunksize=chunksize)
```
Then the _join_ operation is done over each chunk of lines:

```python
        filtered = []
        chunks_metadata = load_nac_metadata.load_nac_index(
            indfilepath=indfilepath, lblfilepath=lblfilepath
        )
        for (
            chunk_metadata
        ) in chunks_metadata:  # iterate over chunks instead of loading all CSV into RAM
            chunk_footprints = footprints.join(
                chunk_metadata, how="inner", lsuffix="_ode", rsuffix=""
            )

            # redacted...

            filtered.append(chunk_footprints)
        return pandas.concat(filtered).dropna()
```
### Computing pairs (overlay)

`geopandas.overlay` and to some extent `geopandas` [have performance issues](https://gis.stackexchange.com/questions/304263/overlay-union-geopandas-improve-performance).

When we find many image candidates for pairs `geopandas.overlay` explodes (RAM and computation time).

It wastes a lot of time computing a huge number of pairs that are mostly discarded by filters (sun geometry and area)

This PR adds a generator that yields chunks of pairs and filter them as they are generated.

That way RAM usage is kept low and it is possible to abort early if enough pairs were found.

```python
def pairs_iter_from_image_search(imagesearch: "ImageSearch") -> Iterator[GeoDataFrame]:
    gdf: GeoDataFrame = imagesearch.results.dropna()
    # Store index (product id) in column so that it's preserved in spatial join operation
    gdf["prod_id"] = gdf.index

    chunk_row_size = 100
    chunks = [
        gdf[i : i + chunk_row_size] for i in range(0, gdf.shape[0], chunk_row_size)
    ]
    for (chunk_1, chunk_2) in tqdm.tqdm(
        itertools.product(chunks, chunks), total=(len(chunks) ** 2.0)
    ):
        pairs = geopandas.overlay(chunk_1, chunk_2, how="union", keep_geom_type=True)
        # redacted ...
        yield pairs
```

> generator that returns chunks of pairs

And then the generator is used here:

```python
    filtered_pairs = []
    filtered_pairs_count = 0
    for pairs_chunk in pairs_iter_from_image_search(imgs):
        filtered_chunk_pairs = filter_small_overlaps(
            filter_sun_geometry(
                pairs_chunk, incidence_range=(incidence_range_low, incidence_range_high)
            )
        )
        filtered_pairs.append(filtered_chunk_pairs)
        filtered_pairs_count += len(filtered_chunk_pairs)
        if filtered_pairs_count > max_pairs and verbose:
            print(f"found {filtered_pairs_count} pairs > --max-pairs={max_pairs}")
            break

    pairs = pandas.concat(filtered_pairs)
```

## Improved coverage

When looking for a minimal set of pairs that covers an area, it seems the way the code chooses a new point is flawed.

Instead of:

```python
# always pick the same point even if it could not find a pair to cover it...
search_point = remaining_uncovered_poly.representative_point()
```

This PR uses:

```python
# pick a random point in the remaining uncovered poly
search_point = random_points_in_polygon(remaining_uncovered_poly, 1)[0]
```

This change helps with coverage close to the equator where finding pairs is harder.

## New parameters

* `indfilepath` and `lblfilepath`: paths for INDEX.TAB and INDEX.LBL
* `max_pairs`: stop looking for pairs as soon as we found at least `max_pairs`
* `miss_limit`: how many times we may fail to cover a point when providing `--find-covering=True`
* `incidence_range_low`, `incidence_range_high`: filter out pairs for which image sun incidence are outside this range. This helps finding better pairs when close to north/south poles...
* `json_output`: path for dumping the JSON containing the pairs.

## Misc

This PR also modifies the `download_NAC.py` so that it can read pairs from the json written by `find_stereo_pairs.py` and download the corresponding images (in parallel).